### PR TITLE
fix(DB/Gameobject): correct Higher Learning book respawn

### DIFF
--- a/data/sql/updates/db_world/2026_07_10_00.sql
+++ b/data/sql/updates/db_world/2026_07_10_00.sql
@@ -1,0 +1,12 @@
+-- DB update 2026_07_06_00 -> 2026_07_10_00
+--
+-- Higher Learning Dalaran books should despawn after the SmartAI read timer and then use their gameobject respawn timer.
+UPDATE `gameobject_template`
+SET `Data5` = 1
+WHERE `entry` IN (
+    192651, 192652, 192653, 192706, 192707, 192708, 192709, 192710, 192711, 192713,
+    192865, 192866, 192867, 192868, 192869, 192870, 192871, 192872, 192874, 192880,
+    192881, 192882, 192883, 192884, 192885, 192886, 192887, 192888, 192889, 192890,
+    192891, 192894, 192895, 192896, 192905
+)
+AND `type` = 10;


### PR DESCRIPTION
## Changes Proposed
- Mark all Dalaran Higher Learning book pool candidates as consumable goobers (`Data5 = 1`).
- This lets the existing SmartAI read timer's `GO_JUST_DEACTIVATED` action schedule the normal `spawntimesecs` respawn instead of immediately resetting the active book.
- Covers both the achievement books and decoy books in pools 5691-5698, so any read book can despawn and later reroll its pool.

## Source reasoning
- The book SmartAI already starts a 240000 ms timed event on gossip/use and then sets loot state 3.
- In core, goober `Data5` maps to `goober.consumable`, which drives `IsDespawnAtAction()`.
- Without `Data5 = 1`, `GO_JUST_DEACTIVATED` returns the object to `GO_READY`; with it, the object uses its configured 10800 second respawn timer.

## Tests Performed
- Verified by source/SQL inspection.
- Verified branch diff against ChromieCraft `master` contains only `data/sql/updates/db_world/2026_07_10_00.sql`.
- No local worldserver runtime test performed.

Also submitted upstream to AzerothCore as https://github.com/azerothcore/azerothcore-wotlk/pull/26546.